### PR TITLE
Add fromValue & returnedBy to replace some can-compute use cases

### DIFF
--- a/can-value.js
+++ b/can-value.js
@@ -2,6 +2,7 @@ var canKey = require("can-key");
 var canReflect = require("can-reflect");
 var keyObservable = require("can-simple-observable/key/key");
 var Observation = require("can-observation");
+var SimpleObservable = require("can-simple-observable");
 
 module.exports = {
 	bind: function(object, keyPath) {
@@ -22,6 +23,14 @@ module.exports = {
 		}
 		//!steal-remove-end
 
+		return new Observation(observationFunction);
+	},
+
+	fromValue: function(initialValue) {
+		return new SimpleObservable(initialValue);
+	},
+
+	returnedBy: function(observationFunction) {
 		return new Observation(observationFunction);
 	},
 

--- a/can-value.md
+++ b/can-value.md
@@ -4,6 +4,7 @@
 @collection can-core
 @description Get an observable that’s bound to a specific property on another object.
 @group can-value/methods methods
+@outline 2
 
 @type {Object}
 
@@ -17,6 +18,12 @@
     from(object, keyPath)
     // Returns an observable for only getting a property on an object.
 
+    fromValue(initialValue)
+    // Creates an observable with an initial value that can be read, written, and observed.
+
+    returnedBy(getter)
+    // Creates an observable that derives its value from other observable values.
+
     to(object, keyPath)
     // Returns an observable for only setting a property on an object.
 }
@@ -25,6 +32,66 @@
 @body
 
 ## Use
+
+### Observable from an initial value
+
+At its simplest, [can-value.fromValue can-value.fromValue()] can be used to
+create an observable from another initial value:
+
+```js
+import canValue from "can-value";
+
+const observable = canValue.fromValue(15);
+
+observable.value; // is 15
+```
+
+You can use [can-reflect/observe.onValue can-reflect.onValue()] to listen for
+when the observable value changes:
+
+```js
+const handler = function(newValue) {
+  newValue; // is 22
+};
+canReflect.onValue(observable, handler);
+observable.value = 22;
+```
+
+### Observable derived from other values
+
+[can-value.returnedBy can-value.returnedBy()] can be used to create an
+observable value that derives its value from other observable values. When the
+derived values change, the observable’s value will be updated automatically.
+
+The following creates a `fullName` observable that derives its values from the
+`person` observable. The value of the observable is read with `fullName.value`:
+
+```js
+import canReflect from "can-reflect";
+import canValue from "can-value";
+import observe from "can-observe";
+
+const person = observe( { first: "Grace", last: "Murray" } );
+
+const fullName = value.returnedBy( function() {
+	return person.first + " " + person.last;
+} );
+fullName.value; // is "Grace Murray"
+```
+
+You can use [can-reflect/observe.onValue can-reflect.onValue()] to listen for
+when the observable value changes (because one of the values from which the
+observable derives its value changed):
+
+```js
+const handler = function(newValue) {
+  newValue; // is "Grace Hopper"
+};
+canReflect.onValue(fullName, handler);
+person.last = "Hopper";
+```
+
+### Bind to other objects
 
 Use `can-value` when you need an observable that can get or set a property on an object.
 

--- a/doc/fromValue.md
+++ b/doc/fromValue.md
@@ -1,0 +1,37 @@
+@function can-value.fromValue fromValue
+@parent can-value/methods
+
+@description Creates an observable value from an initial value.
+
+@signature `canValue.fromValue( initialValue )`
+
+Creates an observable value that can be read, written, and observed using [can-reflect].
+
+```js
+import canValue from "can-value";
+
+const observable = canValue.fromValue("one");
+
+canReflect.getValue(observable); // is "one"
+observable.value; // is "one"
+
+canReflect.setValue(observable, "two");
+observable.value; // is "two"
+
+observable.value = "three";
+observable.value; // is "three"
+
+const handler = function(newValue) {
+  newValue; // is "four"
+};
+canReflect.onValue(observable, handler);
+observable.value = "four";
+
+canReflect.offValue(observable, handler);
+```
+
+@param {*} initialValue The initial value of the observable.
+
+@return {Object} An observable compatible with [can-reflect.getValue can-reflect.getValue()]
+and [can-reflect.setValue can-reflect.setValue()]; it also has a `value` property that can
+be used to get and set the value.

--- a/doc/returnedBy.md
+++ b/doc/returnedBy.md
@@ -1,0 +1,38 @@
+@function can-value.returnedBy returnedBy
+@parent can-value/methods
+
+@description Creates an observable that derives its value from other observable values.
+
+@signature `canValue.returnedBy( getter )`
+
+Creates an observable value that can be read and observed using [can-reflect].
+
+The following creates a `fullName` observable that derives its values from the
+`person` observable. The value of the observable is read with `fullName.value`:
+
+```js
+import canReflect from "can-reflect";
+import canValue from "can-value";
+import observe from "can-observe";
+
+const person = observe( { first: "Grace", last: "Murray" } );
+
+const fullName = value.returnedBy( function() {
+	return person.first + " " + person.last;
+} );
+fullName.value; // is "Grace Murray"
+
+const handler = function(newValue) {
+  newValue; // is "Grace Hopper"
+};
+canReflect.onValue(fullName, handler);
+person.last = "Hopper";
+
+canReflect.offValue(observable, handler);
+```
+
+@param {function} getter A function that returns the value being observed.
+
+@return {Object} An observable compatible with [can-reflect.getValue can-reflect.getValue()]
+and [can-reflect.setValue can-reflect.setValue()]; it also has a `value` property that can
+be used to get and set the value.

--- a/test/test.js
+++ b/test/test.js
@@ -104,6 +104,34 @@ onlyDevTest("from method observable has dependency data", function(assert) {
 	);
 });
 
+QUnit.test("fromValue method works", function() {
+	var observable = canValue.fromValue(15);
+
+	// Test getting the value
+	QUnit.equal(canReflect.getValue(observable), 15, "getting works");
+
+	// Test setting the value
+	canReflect.setValue(observable, 22);
+	QUnit.equal(canReflect.getValue(observable), 22, "setting works");
+});
+
+QUnit.test("returnedBy method works", function() {
+	var person = new SimpleMap({
+		first: "Grace",
+		last: "Murray"
+	});
+	var observable = canValue.returnedBy(function() {
+		return person.get("first") + " " + person.get("last");
+	});
+
+	// Test getting the value
+	QUnit.equal(canReflect.getValue(observable), "Grace Murray", "getting works");
+
+	// Test setting the value
+	person.set("last", "Hopper");
+	QUnit.equal(canReflect.getValue(observable), "Grace Hopper", "setting works");
+});
+
 QUnit.test("to method works", function() {
 	var outer = {inner: {key: "hello"}};
 	var setProp = canValue.to(outer, "inner.key");


### PR DESCRIPTION
This adds two new methods, `fromValue()` and `returnedBy()`, to cover the initial value and simple getter use cases from can-compute (respectively):

```js
import value from "can-value";

const age = value.fromValue(32);
const nameAndAge = value.returnedBy(function() {
	return "Matthew - " + age.value;
});

// Get the value
nameAndAge.value; // -> Matthew - 32

// Set the value
age.value = 33;
nameAndAge.value; // -> Matthew - 33
```

Part of https://github.com/canjs/can-value/issues/5